### PR TITLE
Added support for Debian Stretch and Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ cache:
   directories: [ '$HOME/lxc' ]
   pip: true
 env:
+  - LXC_DISTRO=debian LXC_RELEASE=stretch
   - LXC_DISTRO=debian LXC_RELEASE=jessie
   - LXC_DISTRO=debian LXC_RELEASE=wheezy
   - LXC_DISTRO=ubuntu LXC_RELEASE=xenial
   - LXC_DISTRO=ubuntu LXC_RELEASE=trusty
+  - LXC_DISTRO=ubuntu LXC_RELEASE=precise
   - LXC_DISTRO=centos LXC_RELEASE=7
   - LXC_DISTRO=centos LXC_RELEASE=6
 before_cache:

--- a/tasks/debian-stretch.yml
+++ b/tasks/debian-stretch.yml
@@ -1,0 +1,11 @@
+---
+- name: Create Debian Stretch (9) test container(s)
+  lxc_container:
+    name: "{{ host_prefix }}{{ '%s' | format(item) }}"
+    template: "{{ template }}"
+    template_options: "--release {{ release }} --mirror http://mirrors.us.kernel.org/debian --packages python,ca-certificates,curl,sudo"
+    container_config: "{{ container_config }}"
+    state: started
+  with_sequence: count="{{ host_quantity | int }}" format="%02d"
+
+# vim:ft=ansible:

--- a/tasks/ubuntu-precise.yml
+++ b/tasks/ubuntu-precise.yml
@@ -1,0 +1,11 @@
+---
+- name: Create Ubuntu Precise Pangolin (12.04) test container(s)
+  lxc_container:
+    name: "{{ host_prefix }}{{ '%s' | format(item) }}"
+    template: "{{ template }}"
+    template_options: "--release {{ release }} --mirror http://mirrors.us.kernel.org/ubuntu --packages python,ca-certificates,curl,sudo"
+    container_config: "{{ container_config }}"
+    state: started
+  with_sequence: count="{{ host_quantity | int }}" format="%02d"
+
+# vim:ft=ansible:


### PR DESCRIPTION
First off,  thanks for the awesome role! I was looking for exactly this :)

As the title says I added support for Debian Stretch (9) and Ubuntu Precise (12.04). I copied the configuration as they were for Ubuntu 14.04 and Debian 8 and edited the titles. Have not run into an issue yet.
You can see them working here (https://travis-ci.org/wilmardo/ansible-role-plex/builds/267522738) and they work flawless. 

The documentation is a bit sparse but after some digging I got everything working fine. Is it cool if I rework your documentation a bit? (If I still have time left ;))