### PR TITLE
Fedora support, closes #13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
   - LXC_DISTRO=ubuntu LXC_RELEASE=precise
   - LXC_DISTRO=centos LXC_RELEASE=7
   - LXC_DISTRO=centos LXC_RELEASE=6
+  - LXC_DISTRO=fedora LXC_RELEASE=24
+  - LXC_DISTRO=fedora LXC_RELEASE=25
+  - LXC_DISTRO=fedora LXC_RELEASE=26
   - LXC_DISTRO=ubuntu LXC_RELEASE=xenial ANSIBLE_VERSION='ansible>=2.2.0,<2.3.0' #2.2.x
   - LXC_DISTRO=ubuntu LXC_RELEASE=xenial ANSIBLE_VERSION='ansible>=2.3.0,<2.4.0' #2.3.x
   - LXC_DISTRO=ubuntu LXC_RELEASE=xenial ANSIBLE_VERSION='ansible>=2.4.0,<2.5.0' #2.4.x

--- a/tasks/centos-6.yml
+++ b/tasks/centos-6.yml
@@ -3,7 +3,7 @@
   lxc_container:
     name: "{{ host_prefix }}{{ '%s' | format(item) }}"
     template: "{{ template }}"
-    template_options: "-R {{ release }}"
+    template_options: "--release {{ release }}"
     container_config: "{{ container_config }}"
     state: started
   register: __centos_cts

--- a/tasks/fedora-24-post.yml
+++ b/tasks/fedora-24-post.yml
@@ -2,7 +2,7 @@
 - name: Post configuration on Fedora 24 container(s)
   lxc_container:
     name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
-    container_command: "yum install -y epel-release ca-certificates sudo redhat-lsb-core"
+    container_command: "yum install -y ca-certificates python"
   with_sequence: count="{{ host_quantity | int }}"
   when: __fedora_cts.results[(item|int)-1] | changed
 

--- a/tasks/fedora-24-post.yml
+++ b/tasks/fedora-24-post.yml
@@ -1,0 +1,9 @@
+---
+- name: Post configuration on Fedora 24 container(s)
+  lxc_container:
+    name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
+    container_command: "yum install -y epel-release ca-certificates sudo redhat-lsb-core"
+  with_sequence: count="{{ host_quantity | int }}"
+  when: __fedora_cts.results[(item|int)-1] | changed
+
+# vim:ft=ansible:

--- a/tasks/fedora-24-post.yml
+++ b/tasks/fedora-24-post.yml
@@ -2,7 +2,7 @@
 - name: Post configuration on Fedora 24 container(s)
   lxc_container:
     name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
-    container_command: "yum install -y ca-certificates python"
+    container_command: "dnf install -y ca-certificates python"
   with_sequence: count="{{ host_quantity | int }}"
   when: __fedora_cts.results[(item|int)-1] | changed
 

--- a/tasks/fedora-24.yml
+++ b/tasks/fedora-24.yml
@@ -1,12 +1,12 @@
 ---
-- name: Create CentOS 7 test container(s)
+- name: Create Fedora 24 test container(s)
   lxc_container:
     name: "{{ host_prefix }}{{ '%s' | format(item) }}"
     template: "{{ template }}"
     template_options: "--release {{ release }}"
     container_config: "{{ container_config }}"
     state: started
-  register: __centos_cts
+  register: __fedora_cts
   environment:
     root_expire_password: no
   with_sequence: count="{{ host_quantity | int }}" format="%02d"

--- a/tasks/fedora-25-post.yml
+++ b/tasks/fedora-25-post.yml
@@ -2,7 +2,7 @@
 - name: Post configuration on Fedora 25 container(s)
   lxc_container:
     name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
-    container_command: "yum install -y epel-release ca-certificates sudo redhat-lsb-core"
+    container_command: "yum install -y ca-certificates python"
   with_sequence: count="{{ host_quantity | int }}"
   when: __fedora_cts.results[(item|int)-1] | changed
 

--- a/tasks/fedora-25-post.yml
+++ b/tasks/fedora-25-post.yml
@@ -1,0 +1,9 @@
+---
+- name: Post configuration on Fedora 25 container(s)
+  lxc_container:
+    name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
+    container_command: "yum install -y epel-release ca-certificates sudo redhat-lsb-core"
+  with_sequence: count="{{ host_quantity | int }}"
+  when: __fedora_cts.results[(item|int)-1] | changed
+
+# vim:ft=ansible:

--- a/tasks/fedora-25-post.yml
+++ b/tasks/fedora-25-post.yml
@@ -2,7 +2,7 @@
 - name: Post configuration on Fedora 25 container(s)
   lxc_container:
     name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
-    container_command: "yum install -y ca-certificates python"
+    container_command: "dnf install -y ca-certificates python"
   with_sequence: count="{{ host_quantity | int }}"
   when: __fedora_cts.results[(item|int)-1] | changed
 

--- a/tasks/fedora-25.yml
+++ b/tasks/fedora-25.yml
@@ -1,12 +1,12 @@
 ---
-- name: Create CentOS 7 test container(s)
+- name: Create Fedora 25 test container(s)
   lxc_container:
     name: "{{ host_prefix }}{{ '%s' | format(item) }}"
     template: "{{ template }}"
     template_options: "--release {{ release }}"
     container_config: "{{ container_config }}"
     state: started
-  register: __centos_cts
+  register: __fedora_cts
   environment:
     root_expire_password: no
   with_sequence: count="{{ host_quantity | int }}" format="%02d"

--- a/tasks/fedora-26-post.yml
+++ b/tasks/fedora-26-post.yml
@@ -2,7 +2,7 @@
 - name: Post configuration on Fedora 26 container(s)
   lxc_container:
     name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
-    container_command: "yum install -y epel-release ca-certificates sudo redhat-lsb-core"
+    container_command: "yum install -y ca-certificates python"
   with_sequence: count="{{ host_quantity | int }}"
   when: __fedora_cts.results[(item|int)-1] | changed
 

--- a/tasks/fedora-26-post.yml
+++ b/tasks/fedora-26-post.yml
@@ -2,7 +2,7 @@
 - name: Post configuration on Fedora 26 container(s)
   lxc_container:
     name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
-    container_command: "yum install -y ca-certificates python"
+    container_command: "dnf install -y ca-certificates python"
   with_sequence: count="{{ host_quantity | int }}"
   when: __fedora_cts.results[(item|int)-1] | changed
 

--- a/tasks/fedora-26-post.yml
+++ b/tasks/fedora-26-post.yml
@@ -1,0 +1,9 @@
+---
+- name: Post configuration on Fedora 26 container(s)
+  lxc_container:
+    name: "{{ __fedora_cts.results[(item|int)-1].lxc_container.name }}"
+    container_command: "yum install -y epel-release ca-certificates sudo redhat-lsb-core"
+  with_sequence: count="{{ host_quantity | int }}"
+  when: __fedora_cts.results[(item|int)-1] | changed
+
+# vim:ft=ansible:

--- a/tasks/fedora-26.yml
+++ b/tasks/fedora-26.yml
@@ -1,12 +1,12 @@
 ---
-- name: Create CentOS 7 test container(s)
+- name: Create Fedora 26 test container(s)
   lxc_container:
     name: "{{ host_prefix }}{{ '%s' | format(item) }}"
     template: "{{ template }}"
     template_options: "--release {{ release }}"
     container_config: "{{ container_config }}"
     state: started
-  register: __centos_cts
+  register: __fedora_cts
   environment:
     root_expire_password: no
   with_sequence: count="{{ host_quantity | int }}" format="%02d"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,8 +36,9 @@
 
 - name: Install needed Python libraries
   pip:
-    name: "{{ travis_lxc_eggs }}"
+    name: "{{ item }}"
     state: latest
+  with_items: "{{ travis_lxc_eggs }}"
 
 - name: Create SSH directory for current user
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for ansible-role-travis-lxc
 - set_fact:
     ansible_python_interpreter: "{{ lookup('env', 'VIRTUAL_ENV') }}/bin/python"
+    container_config: "{{ container_config }} + {{ network_config }}"
 
 - block:
   - name: Symlink OS python-apt into Travis Python virtualenv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for ansible-role-travis-lxc
 - set_fact:
     ansible_python_interpreter: "{{ lookup('env', 'VIRTUAL_ENV') }}/bin/python"
-    container_config: "{{ container_config }} + {{ network_config }}"
+    container_config: "{{ container_config }} + {{ travis_lxc_network_config }}"
 
 - block:
   - name: Symlink OS python-apt into Travis Python virtualenv

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,3 +8,7 @@ travis_lxc_packages:
   - debootstrap
 travis_lxc_eggs:
   - lxc-python2
+network config:
+  - "lxc.net.0.type = veth"
+  - "lxc.net.0.link = lxcbr0"
+  - "lxc.net.0.flags = up"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,7 @@ travis_lxc_packages:
   - debootstrap
 travis_lxc_eggs:
   - lxc-python2
-network config:
+network_config:
   - "lxc.net.0.type = veth"
   - "lxc.net.0.link = lxcbr0"
   - "lxc.net.0.flags = up"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,7 +8,7 @@ travis_lxc_packages:
   - debootstrap
 travis_lxc_eggs:
   - lxc-python2
-network_config:
+travis_lxc_network_config:
   - "lxc.net.0.type = veth"
   - "lxc.net.0.link = lxcbr0"
   - "lxc.net.0.flags = up"


### PR DESCRIPTION
- Fixes issue #13 
- Adds `network_config` variable as discussed in issue #13 
- Normalized --release tag (removed the -R shorthand used in some of the template_options)
- `with_items` added to pip task, seems more logical since the `travis_lxc_eggs` is a list