### PR TITLE
Integrated LXC container caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: required
 dist: trusty
 cache:
-  timeout: 600
   directories:
   - "$HOME/lxc"
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 - ANSIBLE_VERSION='<2.4.0' # 2.3.x
 - LXC_DISTRO=ubuntu LXC_RELEASE=xenial TEST=-v0.6.1 # Backwards compatibility test
 install:
+- ls -lh $HOME/lxc
 - if [ "$ANSIBLE_GIT_VERSION" ]; then pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_GIT_VERSION}.tar.gz";
   elif [ "$ANSIBLE_VERSION" ]; then pip install "ansible${ANSIBLE_VERSION}";
   else pip install ansible; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: required
 dist: trusty
 cache:
+  timeout: 600
   directories:
   - "$HOME/lxc"
   pip: true
@@ -13,11 +14,7 @@ env:
 - ANSIBLE_VERSION='<2.5.0' # 2.4.x
 - ANSIBLE_VERSION='<2.4.0' # 2.3.x
 - LXC_DISTRO=ubuntu LXC_RELEASE=xenial TEST=-v0.6.1 # Backwards compatibility test
-before_cache:
-- sudo mkdir $HOME/lxc && sudo tar cf $HOME/lxc/cache.tar /var/cache/lxc/ && sudo
-  chown $USER. $HOME/lxc/cache.tar
 install:
-- sudo tar xf $HOME/lxc/cache.tar -C / || true
 - if [ "$ANSIBLE_GIT_VERSION" ]; then pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_GIT_VERSION}.tar.gz";
   elif [ "$ANSIBLE_VERSION" ]; then pip install "ansible${ANSIBLE_VERSION}";
   else pip install ansible; fi

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,4 +14,4 @@ container_config:
 additional_packages: []
 lxc_cache_enabled: yes
 lxc_cache_directory: "/home/{{ ansible_user_id }}/lxc"
-lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"
+#lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,6 @@ container_config:
   - "lxc.mount.auto = proc:rw sys:rw cgroup-full:rw"
   - "lxc.cgroup.devices.allow = a *:* rmw"
 additional_packages: []
+lxc_cache_enabled: yes
+lxc_cache_directory: "/home/{{ ansible_user_id }}/lxc"
+lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,5 @@ container_config:
   - "lxc.mount.auto = proc:rw sys:rw cgroup-full:rw"
   - "lxc.cgroup.devices.allow = a *:* rmw"
 additional_packages: []
-lxc_cache_enabled: yes
 lxc_cache_directory: "/home/{{ ansible_user_id }}/lxc"
 #lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,29 @@
     ssh_key_comment: "{{ ansible_user_id }}@{{ ansible_hostname }}-lxctest"
 
 - block:
+  - name: Extract all cached container root filesystems
+    shell: "tar -C / -xf {{ __rootfs_tarball }} && rm {{ __rootfs_tarball }}"
+    async: 1800
+    poll: 0
+    changed_when: false
+    register: __cache_restore_jobs
+    args:
+      warn: false
+      creates: "{{ travis_lxc_profiles[item].rootfs }}"
+    with_items: "{{ lxc_cache_profiles }}"
+    when: lxc_cache_enabled
+    vars:
+      __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar"
+
+  - name: Wait until cached root filesystems have been extracted
+    async_status:
+      jid: "{{ item.ansible_job_id }}"
+    register: __cache_restore
+    ignore_errors: true
+    until: __cache_restore.finished
+    with_items: "{{ __cache_restore_jobs.results }}"
+    when: "lxc_cache_enabled and 'ansible_job_id' in item"
+
   - name: Prepare a single LXC container per profile as a base container
     lxc_container:
       name: "{{ item.prefix | default(item.profile) }}"
@@ -81,6 +104,30 @@
     retries: 300
     with_items: "{{ __post_bootstrap_jobs.results }}"
     when: "'ansible_job_id' in item"
+
+  - name: Archive all container root filesystems
+    shell: "tar --mtime=0 -cf {{ __rootfs_tarball }} {{ travis_lxc_profiles[item].rootfs }} && chown {{ ansible_user_id }}: {{ lxc_cache_directory }}/{{ item }}.tar"
+    async: 1800
+    poll: 0
+    changed_when: false
+    register: __cache_save_jobs
+    args:
+      warn: false
+      creates: "{{ __rootfs_tarball }}"
+    with_items: "{{ lxc_cache_profiles }}"
+    when: lxc_cache_enabled
+    vars:
+      __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar"
+
+  - name: Wait for all root filesystem archivals to complete
+    async_status:
+      jid: "{{ item.ansible_job_id }}"
+    register: __cache_save
+    ignore_errors: true
+    until: __cache_save.finished
+    retries: 100
+    with_items: "{{ __cache_save_jobs.results }}"
+    when: "lxc_cache_enabled and 'ansible_job_id' in item"
 
   - name: Create an .ssh directory in the base containers
     file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for ansible-role-travis-lxc
+# tasks file for lae.travis-lxc
 - set_fact:
     ansible_python_interpreter: "{{ lookup('env', 'VIRTUAL_ENV') }}/bin/python"
     container_config: "{{ container_config }} + {{ travis_lxc_network_config }}"
@@ -23,7 +23,7 @@
 
 - block:
   - name: Extract all cached container root filesystems
-    shell: "tar -C / -I pigz -xf {{ __rootfs_tarball }} && rm {{ __rootfs_tarball }}"
+    shell: "[ -f {{ __rootfs_tarball }} ] && tar -C / -I pigz -xf {{ __rootfs_tarball }}"
     async: 1800
     poll: 0
     changed_when: false
@@ -31,7 +31,6 @@
     args:
       warn: false
       creates: "{{ travis_lxc_profiles[item].rootfs }}"
-      removes: "{{ __rootfs_tarball }}"
     with_items: "{{ lxc_cache_profiles }}"
     when: lxc_cache_enabled
     vars:
@@ -108,7 +107,11 @@
     when: "'ansible_job_id' in item"
 
   - name: Archive all container root filesystems
-    shell: "tar --mtime=0 -I pigz -cf {{ __rootfs_tarball }} {{ travis_lxc_profiles[item].rootfs }} && chown {{ ansible_user_id }}: {{ __rootfs_tarball }}"
+    shell: >-
+      modified_file_count=$(find {{ __rootfs }} -newermt "$(uptime -s)" -type f {% for path in __rootfs_exclude %}-not -path "{{ __rootfs }}{{ path }}" {% endfor %} | wc -l);
+      [ $modified_file_count -gt 0 -o ! -f {{ __rootfs_tarball }} ] &&
+      tar --mtime=@0 -I pigz {% for path in __rootfs_exclude %}--exclude="{{ __rootfs }}{{ path }}" {% endfor %} -cf {{ __rootfs_tarball }} {{ __rootfs }} &&
+      chown {{ ansible_user_id }}: {{ __rootfs_tarball }}
     async: 1800
     poll: 0
     changed_when: false
@@ -119,6 +122,8 @@
     with_items: "{{ lxc_cache_profiles }}"
     when: lxc_cache_enabled
     vars:
+      __rootfs: "{{ travis_lxc_profiles[item].rootfs }}"
+      __rootfs_exclude: "{{ travis_lxc_profiles[item].rootfs_exclude }}"
       __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar.gz"
 
   - name: Wait for all root filesystem archivals to complete

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - block:
   - name: Extract all cached container root filesystems
-    shell: "tar -C / -xf {{ __rootfs_tarball }} && rm {{ __rootfs_tarball }}"
+    shell: "tar -C / -I pigz -xf {{ __rootfs_tarball }} && rm {{ __rootfs_tarball }}"
     async: 1800
     poll: 0
     changed_when: false
@@ -35,7 +35,7 @@
     with_items: "{{ lxc_cache_profiles }}"
     when: lxc_cache_enabled
     vars:
-      __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar"
+      __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar.gz"
 
   - name: Wait until cached root filesystems have been extracted
     async_status:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,12 +106,26 @@
     with_items: "{{ __post_bootstrap_jobs.results }}"
     when: "'ansible_job_id' in item"
 
+  # Here we're identifying if any files, excepting those that match rootfs_exclude
+  # in our profiles, have been modified since the environment was booted. If so,
+  # or if we don't find a cached tarball for the profile we're executing on,
+  # we'll create a compressed tarball using parallel gzip and setting all file
+  # modification times to the unix epoch of the rootfs (w/o excludes).
   - name: Archive all container root filesystems
-    shell: >-
-      modified_file_count=$(find {{ __rootfs }} -newermt "$(uptime -s)" -type f {% for path in __rootfs_exclude %}-not -path "{{ __rootfs }}{{ path }}" {% endfor %} | wc -l);
+    shell: "
+      modified_file_count=$(
+        find {{ __rootfs }} -newermt \"$(uptime -s)\" -type f
+          {% for path in __rootfs_exclude %}
+          -not -path \"{{ __rootfs }}{{ path }}\"
+          {% endfor %}
+        | wc -l);
       [ $modified_file_count -gt 0 -o ! -f {{ __rootfs_tarball }} ] &&
-      tar --mtime=@0 -I pigz {% for path in __rootfs_exclude %}--exclude="{{ __rootfs }}{{ path }}" {% endfor %} -cf {{ __rootfs_tarball }} {{ __rootfs }} &&
-      chown {{ ansible_user_id }}: {{ __rootfs_tarball }}
+      tar --mtime=@0 -I pigz
+        {% for path in __rootfs_exclude %}
+        --exclude=\"{{ __rootfs }}{{ path }}\"
+        {% endfor %}
+        -cf {{ __rootfs_tarball }} {{ __rootfs }} &&
+      chown {{ ansible_user_id }}: {{ __rootfs_tarball }}"
     async: 1800
     poll: 0
     changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,6 +31,7 @@
     args:
       warn: false
       creates: "{{ travis_lxc_profiles[item].rootfs }}"
+      removes: "{{ __rootfs_tarball }}"
     with_items: "{{ lxc_cache_profiles }}"
     when: lxc_cache_enabled
     vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
     register: __cache_restore
     ignore_errors: true
     until: __cache_restore.finished
+    retries: 100
     with_items: "{{ __cache_restore_jobs.results }}"
     when: "lxc_cache_enabled and 'ansible_job_id' in item"
 
@@ -107,7 +108,7 @@
     when: "'ansible_job_id' in item"
 
   - name: Archive all container root filesystems
-    shell: "tar --mtime=0 -cf {{ __rootfs_tarball }} {{ travis_lxc_profiles[item].rootfs }} && chown {{ ansible_user_id }}: {{ lxc_cache_directory }}/{{ item }}.tar"
+    shell: "tar --mtime=0 -I pigz -cf {{ __rootfs_tarball }} {{ travis_lxc_profiles[item].rootfs }} && chown {{ ansible_user_id }}: {{ __rootfs_tarball }}"
     async: 1800
     poll: 0
     changed_when: false
@@ -118,7 +119,7 @@
     with_items: "{{ lxc_cache_profiles }}"
     when: lxc_cache_enabled
     vars:
-      __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar"
+      __rootfs_tarball: "{{ lxc_cache_directory }}/{{ item }}.tar.gz"
 
   - name: Wait for all root filesystem archivals to complete
     async_status:

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -35,6 +35,17 @@
   vars:
     __invalid_profiles: "{{ (test_profiles | map(attribute='profile') | list) | difference(travis_lxc_profiles.keys()) }}"
 
+- set_fact:
+    lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"
+  when: lxc_cache_profiles is not defined
+
+- assert:
+    that: "__invalid_cache_profiles == []"
+    msg: "The following cache profile(s) were specified but not present in test_profiles: {{ __invalid_cache_profiles | join(' ') }}"
+  when: lxc_cache_enabled
+  vars:
+    __invalid_cache_profiles: "{{ lxc_cache_profiles | difference(test_profiles | map(attribute='profile') | list) }}"
+
 - assert:
     that: "\
       {% set __found_prefixes = [] %}\
@@ -68,10 +79,3 @@
 - set_fact:
     test_host_suffixes: "[{% for n in range(0, test_hosts_per_profile | default(1) | int) %}'{{ '%02d' | format(n+1) }}',{% endfor %}]"
   when: test_host_suffixes is not defined
-
-- assert:
-    that: "__invalid_cache_profiles == []"
-    msg: "The following cache profile(s) were specified but not present in test_profiles: {{ __invalid_cache_profiles | join(' ') }}"
-  when: lxc_cache_enabled
-  vars:
-    __invalid_cache_profiles: "{{ lxc_cache_profiles | difference(test_profiles | map(attribute='profile') | list) }}"

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -35,16 +35,30 @@
   vars:
     __invalid_profiles: "{{ (test_profiles | map(attribute='profile') | list) | difference(travis_lxc_profiles.keys()) }}"
 
-- set_fact:
-    lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"
-  when: lxc_cache_profiles is not defined
+- block:
+  - name: If left unspecified, set caching profiles to match test profiles
+    set_fact:
+      lxc_cache_profiles: "{{ test_profiles | map(attribute='profile') | list }}"
+    when: lxc_cache_profiles is not defined
 
-- assert:
-    that: "__invalid_cache_profiles == []"
-    msg: "The following cache profile(s) were specified but not present in test_profiles: {{ __invalid_cache_profiles | join(' ') }}"
+  - name: Ensure caching profiles are a subset of specified test profiles
+    assert:
+      that: "__invalid_cache_profiles == []"
+      msg: "The following cache profile(s) were specified but not present in test_profiles: {{ __invalid_cache_profiles | join(' ') }}"
+    vars:
+      __invalid_cache_profiles: "{{ lxc_cache_profiles | difference(test_profiles | map(attribute='profile') | list) }}"
+
+  - name: Check for the existence of the LXC cache directory
+    stat:
+      path: "{{ lxc_cache_directory }}"
+    register: __cache_directory
+
+  - name: Disable LXC caching tasks if LXC cache directory doesn't exist
+    set_fact:
+      lxc_cache_enabled: false
+    when: __cache_directory.stat.isdir is defined and not __cache_directory.stat.isdir
+
   when: lxc_cache_enabled
-  vars:
-    __invalid_cache_profiles: "{{ lxc_cache_profiles | difference(test_profiles | map(attribute='profile') | list) }}"
 
 - assert:
     that: "\

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -35,6 +35,17 @@
   vars:
     __invalid_profiles: "{{ (test_profiles | map(attribute='profile') | list) | difference(travis_lxc_profiles.keys()) }}"
 
+# Cache directories specified in .travis.yml are automatically created by Travis
+# so we use that to extrapolate whether or not to enable caching
+- name: Check for the existence of the LXC cache directory
+  stat:
+    path: "{{ lxc_cache_directory }}"
+  register: __cache_directory
+
+- name: Enable LXC caching if the LXC cache directory exists
+  set_fact:
+    lxc_cache_enabled: "{{ __cache_directory.stat.isdir is defined and __cache_directory.stat.isdir }}"
+
 - block:
   - name: If left unspecified, set caching profiles to match test profiles
     set_fact:
@@ -47,17 +58,6 @@
       msg: "The following cache profile(s) were specified but not present in test_profiles: {{ __invalid_cache_profiles | join(' ') }}"
     vars:
       __invalid_cache_profiles: "{{ lxc_cache_profiles | difference(test_profiles | map(attribute='profile') | list) }}"
-
-  - name: Check for the existence of the LXC cache directory
-    stat:
-      path: "{{ lxc_cache_directory }}"
-    register: __cache_directory
-
-  - name: Disable LXC caching tasks if LXC cache directory doesn't exist
-    set_fact:
-      lxc_cache_enabled: false
-    when: __cache_directory.stat.isdir is defined and not __cache_directory.stat.isdir
-
   when: lxc_cache_enabled
 
 - assert:

--- a/tasks/validate_variables.yml
+++ b/tasks/validate_variables.yml
@@ -68,3 +68,10 @@
 - set_fact:
     test_host_suffixes: "[{% for n in range(0, test_hosts_per_profile | default(1) | int) %}'{{ '%02d' | format(n+1) }}',{% endfor %}]"
   when: test_host_suffixes is not defined
+
+- assert:
+    that: "__invalid_cache_profiles == []"
+    msg: "The following cache profile(s) were specified but not present in test_profiles: {{ __invalid_cache_profiles | join(' ') }}"
+  when: lxc_cache_enabled
+  vars:
+    __invalid_cache_profiles: "{{ lxc_cache_profiles | difference(test_profiles | map(attribute='profile') | list) }}"

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -2,3 +2,6 @@
 callback_whitelist=profile_tasks
 forks=20
 internal_poll_interval = 0.001
+
+[ssh_connection]
+retries=3

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -13,6 +13,8 @@ travis_lxc_profiles:
       - sudo
       - gnupg2
     rootfs: /var/cache/lxc/debian/rootfs-wheezy-amd64
+    rootfs_exclude:
+      - "/*.pyc"
   debian-jessie:
     label: "Debian Jessie (8)"
     packages:
@@ -22,6 +24,8 @@ travis_lxc_profiles:
       - sudo
       - gnupg2
     rootfs: /var/cache/lxc/debian/rootfs-jessie-amd64
+    rootfs_exclude:
+      - "/*.pyc"
   debian-stretch:
     label: "Debian Stretch (9)"
     packages:
@@ -31,6 +35,8 @@ travis_lxc_profiles:
       - sudo
       - gnupg2
     rootfs: /var/cache/lxc/debian/rootfs-stretch-amd64
+    rootfs_exclude:
+      - "/*.pyc"
   ubuntu-precise:
     label: "Ubuntu Precise Pangolin (12.04)"
     packages:
@@ -39,6 +45,8 @@ travis_lxc_profiles:
       - curl
       - sudo
     rootfs: /var/cache/lxc/precise/rootfs-amd64
+    rootfs_exclude:
+      - "/*.pyc"
   ubuntu-trusty:
     label: "Ubuntu Trusty Tahr (14.04)"
     packages:
@@ -47,6 +55,8 @@ travis_lxc_profiles:
       - curl
       - sudo
     rootfs: /var/cache/lxc/trusty/rootfs-amd64
+    rootfs_exclude:
+      - "/*.pyc"
   ubuntu-xenial:
     label: "Ubuntu Xenus Xenial (16.04)"
     packages:
@@ -55,6 +65,8 @@ travis_lxc_profiles:
       - curl
       - sudo
     rootfs: /var/cache/lxc/xenial/rootfs-amd64
+    rootfs_exclude:
+      - "/*.pyc"
   centos-6:
     label: "CentOS 6"
     packages:
@@ -65,6 +77,11 @@ travis_lxc_profiles:
     environment:
       root_expire_password: no
     rootfs: /var/cache/lxc/centos/x86_64/6/rootfs
+    rootfs_exclude:
+      - "/*.pyc"
+      - /var/cache/yum
+      - /var/lib/yum/uuid
+      - "/var/lib/rpm/__db.*"
   centos-7:
     label: "CentOS 7"
     packages:
@@ -75,6 +92,11 @@ travis_lxc_profiles:
     environment:
       root_expire_password: no
     rootfs: /var/cache/lxc/centos/x86_64/7/rootfs
+    rootfs_exclude:
+      - "/*.pyc"
+      - /var/cache/yum
+      - /var/lib/yum/uuid
+      - "/var/lib/rpm/__db.*"
   fedora-25:
     label: "Fedora 25"
     packages:
@@ -84,6 +106,15 @@ travis_lxc_profiles:
     environment:
       root_expire_password: no
     rootfs: /var/cache/lxc/fedora/25-x86_64/rootfs
+    rootfs_exclude:
+      - "/*.pyc"
+      - /var/cache/dnf
+      - "/var/lib/rpm/__db.*"
+      - /etc/resolv.conf
+      - /etc/pki/nssdb/key*.db
+      - /etc/pki/nssdb/cert*.db
+      - "/var/log/dnf*.log"
+      - /var/log/hawkey.log
   fedora-26:
     label: "Fedora 26"
     packages:
@@ -93,6 +124,15 @@ travis_lxc_profiles:
     environment:
       root_expire_password: no
     rootfs: /var/cache/lxc/fedora/26-x86_64/rootfs
+    rootfs_exclude:
+      - "/*.pyc"
+      - /var/cache/dnf
+      - "/var/lib/rpm/__db.*"
+      - /etc/resolv.conf
+      - /etc/pki/nssdb/key*.db
+      - /etc/pki/nssdb/cert*.db
+      - "/var/log/dnf*.log"
+      - /var/log/hawkey.log
   fedora-27:
     label: "Fedora 27"
     packages:
@@ -102,6 +142,14 @@ travis_lxc_profiles:
     environment:
       root_expire_password: no
     rootfs: /var/cache/lxc/fedora/27-x86_64/rootfs
+    rootfs_exclude:
+      - "/*.pyc"
+      - /var/cache/dnf
+      - "/var/lib/rpm/__db.*"
+      - /var/lib/rpm/.dbenv.lock
+      - /etc/resolv.conf
+      - "/var/log/dnf*.log"
+      - /var/log/hawkey.log
 travis_lxc_packages:
   - lxc
   - lxc-templates

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,7 @@ travis_lxc_profiles:
       - curl
       - sudo
       - gnupg2
+    rootfs: /var/cache/lxc/debian/rootfs-wheezy-amd64
   debian-jessie:
     label: "Debian Jessie (8)"
     packages:
@@ -20,6 +21,7 @@ travis_lxc_profiles:
       - curl
       - sudo
       - gnupg2
+    rootfs: /var/cache/lxc/debian/rootfs-jessie-amd64
   debian-stretch:
     label: "Debian Stretch (9)"
     packages:
@@ -28,6 +30,7 @@ travis_lxc_profiles:
       - curl
       - sudo
       - gnupg2
+    rootfs: /var/cache/lxc/debian/rootfs-stretch-amd64
   ubuntu-precise:
     label: "Ubuntu Precise Pangolin (12.04)"
     packages:
@@ -35,6 +38,7 @@ travis_lxc_profiles:
       - ca-certificates
       - curl
       - sudo
+    rootfs: /var/cache/lxc/precise/rootfs-amd64
   ubuntu-trusty:
     label: "Ubuntu Trusty Tahr (14.04)"
     packages:
@@ -42,6 +46,7 @@ travis_lxc_profiles:
       - ca-certificates
       - curl
       - sudo
+    rootfs: /var/cache/lxc/trusty/rootfs-amd64
   ubuntu-xenial:
     label: "Ubuntu Xenus Xenial (16.04)"
     packages:
@@ -49,6 +54,7 @@ travis_lxc_profiles:
       - ca-certificates
       - curl
       - sudo
+    rootfs: /var/cache/lxc/xenial/rootfs-amd64
   centos-6:
     label: "CentOS 6"
     packages:
@@ -58,6 +64,7 @@ travis_lxc_profiles:
       - redhat-lsb-core
     environment:
       root_expire_password: no
+    rootfs: /var/cache/lxc/centos/x86_64/6/rootfs
   centos-7:
     label: "CentOS 7"
     packages:
@@ -67,6 +74,7 @@ travis_lxc_profiles:
       - redhat-lsb-core
     environment:
       root_expire_password: no
+    rootfs: /var/cache/lxc/centos/x86_64/7/rootfs
   fedora-25:
     label: "Fedora 25"
     packages:
@@ -75,6 +83,7 @@ travis_lxc_profiles:
       - sudo
     environment:
       root_expire_password: no
+    rootfs: /var/cache/lxc/fedora/25-x86_64/rootfs
   fedora-26:
     label: "Fedora 26"
     packages:
@@ -83,6 +92,7 @@ travis_lxc_profiles:
       - sudo
     environment:
       root_expire_password: no
+    rootfs: /var/cache/lxc/fedora/26-x86_64/rootfs
   fedora-27:
     label: "Fedora 27"
     packages:
@@ -91,6 +101,7 @@ travis_lxc_profiles:
       - sudo
     environment:
       root_expire_password: no
+    rootfs: /var/cache/lxc/fedora/27-x86_64/rootfs
 travis_lxc_packages:
   - lxc
   - lxc-templates

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -109,6 +109,7 @@ travis_lxc_packages:
   - yum
   - debootstrap
   - expect-dev
+  - pigz
 travis_lxc_eggs:
   - lxc-python2
 travis_lxc_network_config:


### PR DESCRIPTION
This moves caching tasks that we otherwise put in `install` and `before_cache` as separate (and in my experience inefficient) steps into the role itself.

To enable it, all we really need is to add the following into `.travis.yml`:

    cache:
      directories:
      - "$HOME/lxc"

A different directory can be specified as well, but the `lxc_cache_directory` role variable must be updated as well.

Caching can be configured on a per profile basis with the `lxc_cache_profiles` role variable. A gzipped tarball is generated for each profile and stored in the `lxc_cache_directory` once base containers are built. On the next build, they are extracted prior to building the base containers. If any files have been modified, other than the ones we ignore in `travis_lxc_profiles[profile].rootfs_exclude`, then the tarball is repackaged - Travis will see this as a change and upload the new cache. Otherwise, Travis will not reupload the cache (thus saving on build time).