### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/tasks/travis_packaging_setup.yml
+++ b/tasks/travis_packaging_setup.yml
@@ -36,6 +36,7 @@
       name: "{{ item }}"
       update_cache: yes
       cache_valid_time: 3600
+      state: latest
     with_items: "{{ travis_lxc_packages }}"
   become: True
 

--- a/tests/deploy.yml
+++ b/tests/deploy.yml
@@ -15,6 +15,7 @@
       - profile: debian-wheezy
       - profile: centos-7
       - profile: centos-6
+      - profile: ubuntu-bionic
       - profile: ubuntu-xenial
       - profile: ubuntu-trusty
       - profile: ubuntu-precise

--- a/tests/inventory
+++ b/tests/inventory
@@ -7,6 +7,7 @@ debian-jessie-[01:02].lxc
 debian-wheezy-[01:02]
 centos-7-[01:02]
 centos-6-01 # ignoring 02, see issue #26
+ubuntu-bionic-[01:02]
 ubuntu-xenial-[01:02]
 ubuntu-trusty-[01:02]
 ubuntu-precise-[01:02]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -83,6 +83,7 @@ travis_lxc_profiles:
       - ca-certificates
       - curl
       - sudo
+      - gnupg2
     rootfs: /var/cache/lxc/bionic/rootfs-amd64
     rootfs_exclude:
       - "/*.pyc"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -65,7 +65,7 @@ travis_lxc_profiles:
     rootfs_exclude:
       - "/*.pyc"
   ubuntu-xenial:
-    label: "Ubuntu Xenus Xenial (16.04)"
+    label: "Ubuntu Xenial Xerus (16.04)"
     prefix: ubuntu-xenial-
     packages:
       - python
@@ -73,6 +73,17 @@ travis_lxc_profiles:
       - curl
       - sudo
     rootfs: /var/cache/lxc/xenial/rootfs-amd64
+    rootfs_exclude:
+      - "/*.pyc"
+  ubuntu-bionic:
+    label: "Ubuntu Bionic Beaver (18.04)"
+    prefix: ubuntu-bionic-
+    packages:
+      - python
+      - ca-certificates
+      - curl
+      - sudo
+    rootfs: /var/cache/lxc/bionic/rootfs-amd64
     rootfs_exclude:
       - "/*.pyc"
   centos-6:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -205,6 +205,7 @@ travis_lxc_packages:
   - lxc
   - lxc-templates
   - lxc-dev
+  - dpkg
   - yum
   - debootstrap
   - expect-dev


### PR DESCRIPTION
Sometimes Travis CI gives me the worst headaches.

dpkg is outdated by almost half a year - the following release is required in order to debootstrap Bionic packages correctly:
https://launchpad.net/ubuntu/+source/dpkg/1.17.5ubuntu5.8
https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627