### PR TITLE
Add debian-archive-keyring to build environment

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -209,6 +209,7 @@ travis_lxc_packages:
   - dpkg
   - yum
   - debootstrap
+  - debian-archive-keyring
   - expect-dev
   - pigz
 travis_lxc_network_config:


### PR DESCRIPTION
Fixes issues where debootstrap fails due to missing new keys.

References:
https://github.com/lxc/lxc/issues/1799#issuecomment-433061603
https://github.com/lxc/lxc/issues/1799#issuecomment-433071646