### PR TITLE
Fixes for python-apt install and Alpine containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-python:
-  - "2.7"
-  - "3.6"
 sudo: required
 dist: bionic
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,20 @@
 language: python
-sudo: required
 dist: bionic
 cache:
   directories:
   - "$HOME/lxc"
   pip: true
-env:
-  - ANSIBLE_VERSION='~=2.9.0'
 matrix:
   fast_finish: true
   include:
-# FIXME: Ansible 2.10.x going through major restructuring.
+# FIXME: Ansible 2.10.x went through major refactoring of how the codebase is
+# managed, which breaks our ansible git version tests.
 # https://groups.google.com/forum/#!msg/ansible-project/eXsoOKEd0Mk/XTgbnPWbCAAJ
 #    - python: '3.6'
-#      env: ANSIBLE_GIT_VERSION='devel' # 2.10.x development branch
-    - python: '3.6'
-      env: ANSIBLE_VERSION='~=2.8.0'
-    - python: '3.6'
-      env: ANSIBLE_VERSION='~=2.7.0'
+#      env: ANSIBLE_GIT_VERSION='devel' # 2.11.x development branch
+    - env: ANSIBLE_VERSION='~=2.10.0'
+    - env: ANSIBLE_VERSION='~=2.9.0'
+    - env: ANSIBLE_VERSION='~=2.8.0'
 # Install expect here since it's just a normal utility and it's needed for
 # reading any playbook errors easily
 addons:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,18 +1,16 @@
 Vagrant.configure("2") do |config|
-  # matjazp/ubuntu-trusty64 is a libvirt box
-  # if you are using virtualbox, change this to ubuntu/trusty64
-  # Reference: https://app.vagrantup.com/matjazp/boxes/ubuntu-trusty64
-  #
   # If you're running into an NFS mount error (using libvirt), you might need
   # to install your distro's NFS server package, enable UDP for nfsd, and start
   # the server (I'd suggest enabling it as well).
   # Reference: https://github.com/hashicorp/vagrant/issues/9666#issuecomment-401931144
-  config.vm.box = "matjazp/ubuntu-trusty64"
+  config.vm.box = "generic/ubuntu1804"
 
   config.vm.provider :libvirt do |libvirt|
     libvirt.memory = 2048
     libvirt.cpus = 2
   end
+
+  config.vm.synced_folder ".", "/vagrant"
 
   # Performs most of the "install" tasks in .travis.yml
   config.vm.provision "shell", privileged: false,

--- a/files/alpine-mknod.patch
+++ b/files/alpine-mknod.patch
@@ -1,0 +1,33 @@
+--- a/usr/share/lxc/templates/lxc-alpine
++++ b/usr/share/lxc/templates/lxc-alpine
+@@ -278,10 +278,15 @@
+	mkdir -p -m 755 dev/pts
+	mkdir -p -m 1777 dev/shm
+
+-	mknod -m 666 dev/zero c 1 5
+-	mknod -m 666 dev/full c 1 7
+-	mknod -m 666 dev/random c 1 8
+-	mknod -m 666 dev/urandom c 1 9
++	OLDIFS=$IFS
++	IFS=':';
++	for node in 5:zero 7:full 8:random 9:urandom; do
++		set -- $node
++		if [ ! -e dev/$2 ]; then
++			mknod -m 666 dev/$2 c 1 $1
++		fi
++	done
++	IFS=$OLDIFS
+
+	local i; for i in $(seq 0 4); do
+		mknod -m 620 dev/tty$i c 4 $i
+@@ -290,7 +295,9 @@
+
+	mknod -m 666 dev/tty c 5 0
+	chown 0:5 dev/tty  # root:tty
+-	mknod -m 620 dev/console c 5 1
++	if [ ! -e dev/console ]; then
++		mknod -m 620 dev/console c 5 1
++	fi
+	mknod -m 666 dev/ptmx c 5 2
+	chown 0:5 dev/ptmx  # root:tty
+ }

--- a/tasks/travis_packaging_setup.yml
+++ b/tasks/travis_packaging_setup.yml
@@ -40,6 +40,16 @@
     file:
       path: /usr/share/lxc/templates/lxc-fedora
       mode: 0755
+
+  - name: Patch Alpine's LXC template to not fail on mknod
+    patch:
+      src: alpine-mknod.patch
+      dest: /usr/share/lxc/templates/lxc-alpine
+
+  - name: Ensure Alpine LXC template is executable
+    file:
+      path: /usr/share/lxc/templates/lxc-alpine
+      mode: 0755
   become: True
 
 - name: Install LXC Python library

--- a/tasks/travis_packaging_setup.yml
+++ b/tasks/travis_packaging_setup.yml
@@ -2,20 +2,25 @@
 - block:
   # This needs to be done using a command module because the apt module is
   # broken in the Travis CI virtualenv by default.
-  - name: Install libapt-pkg-dev as build dependency for python-apt
-    shell: "apt update && apt install -y libapt-pkg-dev"
+  - name: Install python3-apt systemwide
+    shell: "apt update && apt install -y python3-apt"
     args:
-      creates: /usr/lib/x86_64-linux-gnu/libapt-pkg.so
+      creates: /usr/lib/python3/dist-packages/apt
       warn: False
     retries: 3
   become: True
 
 # After this task, the apt module can be used without problem.
-# 1.6.y branch tracks Xenial
-- name: Install the python-apt library from Launchpad
-  pip:
-    name: "https://git.launchpad.net/python-apt/snapshot/1.6.y.tar.gz"
-    virtualenv: "{{ lookup('env', 'VIRTUAL_ENV') }}"
+- name: Install python-apt into virtualenv
+  copy:
+    src: "/usr/lib/python3/dist-packages/{{ item }}"
+    dest: "{{ lookup('env', 'VIRTUAL_ENV') }}/lib/python3.6/site-packages/"
+    remote_src: yes
+  with_items:
+    - apt
+    - aptsources
+    - apt_inst.cpython-36m-x86_64-linux-gnu.so
+    - apt_pkg.cpython-36m-x86_64-linux-gnu.so
 
 - block:
   - name: Install needed packages

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,4 +15,4 @@
       when: "ansible_pkg_mgr == 'apt'"
     - name: Module Test - uri
       uri:
-        url: https://twitter.com
+        url: https://example.com

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -5,25 +5,16 @@ shift
 
 case "$action" in
 "install")
-    # This repository provides the backported libapt-pkg-dev package.
-    if [ ! -f /etc/apt/sources.list.d/computology_apt-backport.list ]; then
-        echo "[TASK] Installing computology/apt-backport repository..."
-        wget -qO- https://packagecloud.io/install/repositories/computology/apt-backport/script.deb.sh | sudo bash
-    fi
     if [ ! -f $VIRTUALENV_PATH/bin/activate ]; then
         echo "[TASK] Installing Ansible dependencies and setting up virtual environment..."
         sudo apt-get update
-        sudo apt-get install -y python-pip python-dev libffi-dev libyaml-dev libssl-dev build-essential git python-virtualenv
-        virtualenv $VIRTUALENV_PATH
+        sudo apt-get install -y python3-pip python3-dev libffi-dev libyaml-dev libssl-dev build-essential pkg-config git python3-venv
+        python3 -m venv $VIRTUALENV_PATH
     fi
     source $VIRTUALENV_PATH/bin/activate
     if [ ! -x $VIRTUALENV_PATH/bin/ansible-playbook ]; then
         echo "[TASK] Installing Ansible..."
-        # pip>9.0 seems to introduce some versioning checks that affect
-        # idempotency of the pip module, and it doesn't look like travis uses
-        # pip>9.0. pip needs to be upgraded for installing cryptography package
-        # correctly, though.
-        pip install -U "pip<9.0.0"
+        pip install -U pip
         pip install ansible
     fi
     echo "[TASK] Packaging lae.travis-lxc role and installing it in guest..."


### PR DESCRIPTION
This fixes some significant breakage under Travis CI and updates testing to currently supported Ansible versions.

As Python 2 is EOL, the python-apt fix is strictly for Python 3.6 (default Python version in Travis CI). This is enough for my use cases currently.